### PR TITLE
Add list of JEPs (and status) to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,26 @@
 
 This repository contains enhancement proposals for the Jupyter ecosystem, known as Jupyter Enhancement Proposals or JEPs. Jupyter Enhancement Proposals will be used when presenting changes or additions that affect multiple components of the Jupyter ecosystem OR changes to a single key component.
 
-## Index of Accepted JEPs
+## Index of JEPs
 
-Below is a list of JEPs that have already been accepted. To view the JEPs that are currently under active discussion, click on the pull request icon to the right.
+Below is a list of JEPs that have been submitted. To view the discussion around each JEP, click on the links below.
+
+1. [Inactive] - [New Notebook Format for improved workflow integration](https://github.com/jupyter/enhancement-proposals/pull/4)
+1. [Inactive] - [Jupyter Extension Generator](https://github.com/jupyter/enhancement-proposals/pull/7)
+1. [Completed] - [Diffing and Merging Notebooks](https://github.com/jupyter/enhancement-proposals/pull/8)
+1. [In progress] - [Kernel Gateway](https://github.com/jupyter/enhancement-proposals/pull/12)
+1. [Submitted] - [Kernel Nanny](https://github.com/jupyter/enhancement-proposals/pull/14)
+1. [Withdrawn] - [Layout Namespaces and Discovery](https://github.com/jupyter/enhancement-proposals/pull/15)
+1. [Submitted] - [Notebook Translation and Localization](https://github.com/jupyter/enhancement-proposals/pull/16)
+1. [Completed] - [Declarative Widgets Extension](https://github.com/jupyter/enhancement-proposals/pull/18)
+1. [Completed] - [Dashboards Notebook Extension](https://github.com/jupyter/enhancement-proposals/pull/17)
+1. [Submitted] - [Standalone Jupyter Server](https://github.com/jupyter/enhancement-proposals/pull/28)
+1. [Completed] - [Move Dashboards Deployment Projects from Incubator to Attic](https://github.com/jupyter/enhancement-proposals/pull/22)
+1. [Submitted] - [Jupyter Template as Metadata](https://github.com/jupyter/enhancement-proposals/pull/23)
+1. [Submitted] - [Simplifying Error Reporting in Jupyter Protocol](https://github.com/jupyter/enhancement-proposals/pull/24)
+1. [In progress] - [Enterprise Gateway](https://github.com/jupyter/enhancement-proposals/pull/25)
+1. [Submitted] - [Add Languare Server Support to Jupyter Server and jupyterlab-monaco](https://github.com/jupyter/enhancement-proposals/pull/26)
+
 
 ## How do I submit a JEP?
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Below is a list of JEPs that have been submitted. To view the discussion around 
 1. [Inactive] - [New Notebook Format for improved workflow integration](https://github.com/jupyter/enhancement-proposals/pull/4)
 1. [Inactive] - [Jupyter Extension Generator](https://github.com/jupyter/enhancement-proposals/pull/7)
 1. [Completed] - [Diffing and Merging Notebooks](https://github.com/jupyter/enhancement-proposals/pull/8)
-1. [In progress] - [Kernel Gateway](https://github.com/jupyter/enhancement-proposals/pull/12)
+1. [Completed] - [Kernel Gateway](https://github.com/jupyter/enhancement-proposals/pull/12)
 1. [Submitted] - [Kernel Nanny](https://github.com/jupyter/enhancement-proposals/pull/14)
 1. [Withdrawn] - [Layout Namespaces and Discovery](https://github.com/jupyter/enhancement-proposals/pull/15)
 1. [Submitted] - [Notebook Translation and Localization](https://github.com/jupyter/enhancement-proposals/pull/16)
@@ -19,7 +19,7 @@ Below is a list of JEPs that have been submitted. To view the discussion around 
 1. [Completed] - [Move Dashboards Deployment Projects from Incubator to Attic](https://github.com/jupyter/enhancement-proposals/pull/22)
 1. [Submitted] - [Jupyter Template as Metadata](https://github.com/jupyter/enhancement-proposals/pull/23)
 1. [Submitted] - [Simplifying Error Reporting in Jupyter Protocol](https://github.com/jupyter/enhancement-proposals/pull/24)
-1. [In progress] - [Enterprise Gateway](https://github.com/jupyter/enhancement-proposals/pull/25)
+1. [Completed] - [Enterprise Gateway](https://github.com/jupyter/enhancement-proposals/pull/25)
 1. [Submitted] - [Add Languare Server Support to Jupyter Server and jupyterlab-monaco](https://github.com/jupyter/enhancement-proposals/pull/26)
 
 


### PR DESCRIPTION
I think it might be nice to number JEPs for easy reference. I needed to create a master list of JEPs that have been submitted. I added this list to the front README. They are ordered (and numbered) by their initial submission date. I also *tried* to infer their status.