### PR TITLE
add table for JEPs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,25 @@ This repository contains enhancement proposals for the Jupyter ecosystem, known 
 
 Below is a list of JEPs that have been submitted. To view the discussion around each JEP, click on the links below.
 
-1. [Inactive] - [New Notebook Format for improved workflow integration](https://github.com/jupyter/enhancement-proposals/pull/4)
-1. [Inactive] - [Jupyter Extension Generator](https://github.com/jupyter/enhancement-proposals/pull/7)
-1. [Completed] - [Diffing and Merging Notebooks](https://github.com/jupyter/enhancement-proposals/pull/8)
-1. [Completed] - [Kernel Gateway](https://github.com/jupyter/enhancement-proposals/pull/12)
-1. [Submitted] - [Kernel Nanny](https://github.com/jupyter/enhancement-proposals/pull/14)
-1. [Withdrawn] - [Layout Namespaces and Discovery](https://github.com/jupyter/enhancement-proposals/pull/15)
-1. [Submitted] - [Notebook Translation and Localization](https://github.com/jupyter/enhancement-proposals/pull/16)
-1. [Completed] - [Declarative Widgets Extension](https://github.com/jupyter/enhancement-proposals/pull/18)
-1. [Completed] - [Dashboards Notebook Extension](https://github.com/jupyter/enhancement-proposals/pull/17)
-1. [Submitted] - [Standalone Jupyter Server](https://github.com/jupyter/enhancement-proposals/pull/28)
-1. [Completed] - [Move Dashboards Deployment Projects from Incubator to Attic](https://github.com/jupyter/enhancement-proposals/pull/22)
-1. [Submitted] - [Jupyter Template as Metadata](https://github.com/jupyter/enhancement-proposals/pull/23)
-1. [Submitted] - [Simplifying Error Reporting in Jupyter Protocol](https://github.com/jupyter/enhancement-proposals/pull/24)
-1. [Completed] - [Enterprise Gateway](https://github.com/jupyter/enhancement-proposals/pull/25)
-1. [Submitted] - [Add Languare Server Support to Jupyter Server and jupyterlab-monaco](https://github.com/jupyter/enhancement-proposals/pull/26)
+### Numerical Index
+
+| Number | Status | Title |
+|--------|--------|-------|
+| 0004   | Inactive | [New Notebook Format for improved workflow integration](https://github.com/jupyter/enhancement-proposals/pull/4) |
+| 0007   | Inactive | [Jupyter Extension Generator](https://github.com/jupyter/enhancement-proposals/pull/7) |
+| 0008 | Completed | [Diffing and Merging Notebooks](https://github.com/jupyter/enhancement-proposals/pull/8) |
+| 0012 | Completed | [Kernel Gateway](https://github.com/jupyter/enhancement-proposals/pull/12) |
+| 0014 | **Submitted** | [Kernel Nanny](https://github.com/jupyter/enhancement-proposals/pull/14) |
+| 0015 | Withdrawn | [Layout Namespaces and Discovery](https://github.com/jupyter/enhancement-proposals/pull/15) |
+| 0016 | **Submitted** | [Notebook Translation and Localization](https://github.com/jupyter/enhancement-proposals/pull/16) |
+| 0017 | Completed | [Dashboards Notebook Extension](https://github.com/jupyter/enhancement-proposals/pull/17) |
+| 0018 | Completed | [Declarative Widgets Extension](https://github.com/jupyter/enhancement-proposals/pull/18) |
+| 0022 | Completed | [Move Dashboards Deployment Projects from Incubator to Attic](https://github.com/jupyter/enhancement-proposals/pull/22) |
+| 0023 | **Submitted** | [Jupyter Template as Metadata](https://github.com/jupyter/enhancement-proposals/pull/23) |
+| 0024 | **Submitted** | [Simplifying Error Reporting in Jupyter Protocol](https://github.com/jupyter/enhancement-proposals/pull/24) |
+| 0025 | Completed | [Enterprise Gateway](https://github.com/jupyter/enhancement-proposals/pull/25) |
+| 0026 | **Submitted** | [Add Language Server Support to Jupyter Server and jupyterlab-monaco](https://github.com/jupyter/enhancement-proposals/pull/26) |
+| 0028 | **Submitted** | [Standalone Jupyter Server](https://github.com/jupyter/enhancement-proposals/pull/28) |
 
 
 ## How do I submit a JEP?


### PR DESCRIPTION
This is a follow-up PR to @Zsailer's #30.

- Assigns unique JEP ids to existing JEPs based on the original PR number
- Moves bullet list to a table
- Bolds submitted status for easy scanning of what is actively under discussion.