### PR TITLE
Adding a distribution section to the JEP JEP and small tweaks

### DIFF
--- a/29-jep-process/README.md
+++ b/29-jep-process/README.md
@@ -133,14 +133,18 @@ a JEP (If yes, it requires a JEP). Under each question is a relevant example pro
 This section describes how information about the JEP process (e.g., new JEPs, updates to
 current JEPs, etc) is communicated to the community.
 
-Note: This JEP repo is the **canonical "source of truth"** for individual JEPs, the JEP process, and activity on JEPs. 
+Note: This JEP repo is the **canonical "source of truth"** for individual JEPs, the JEP process, and activity on JEPs.
 
 ### The JEP public archive website
 
-A list of all current JEPs and the content present in the pull request exists at
-the JEP text, all relevant metadata about the JEP, and links to PRs and issues
-for the JEP. When a JEP enters into a final state (e.g., "Completed",
-"Withdrawn", "Rejected"), it is added to this website.
+A public website contains a readable archive of all JEP proposals.
+It contains list of all JEPs that have entered a "final" state
+(e.g., "Completed", "Withdrawn", "Rejected"). The content of each JEP will
+be displayed in a readable fashion. When a JEP enters into a final state, it
+is added to this website.
+
+Note that the JEPs themselves contain the content, while the website is just a
+quick way to display them in a reading-friendly format.
 
 ## Glossary
 
@@ -152,7 +156,7 @@ for the JEP. When a JEP enters into a final state (e.g., "Completed",
 
 - **Review Team (RT)**: A group of Jupyter contributors, with expertise in a particular area of the project, that reviews JEPs related to that area.
 
-- **Final Comment Period (FCP)**: A finite-time, post-approval period for the community to make final comments.
+- **Final Comment Period (FCP)**: A finite-time, pre-approval period for the community to make final comments.
 
 - JEP Statuses:
 

--- a/29-jep-process/README.md
+++ b/29-jep-process/README.md
@@ -40,7 +40,7 @@ Several sub-goals exist for this process:
 
 With that in mind, the JEP process operates under the following tenets:
 
-- **The JEP process is intended for proposed changes of non-trivial scope.  “**Non-trivial” is addressed below in the “JEP / Not-a-JEP Rubric” of this document.  If proposals that go through the JEP process do not receive the benefits listed above, the JEP process should be amended to better scope what applied.
+- **The JEP process is intended for proposed changes of non-trivial scope.**  “Non-trivial” is addressed below in the “JEP / Not-a-JEP Rubric” of this document.  If proposals that go through the JEP process do not receive the benefits listed above, the JEP process should be amended to better scope what applied.
 
 - **The JEP process naturally complements the PR process, but does not replace it.**  A thoroughly-reviewed and approved JEP is a valuable reference during a PR to reduce friction, reduce time-consuming context sharing, and encapsulate decisions and other discussions.  Moving a premature PR into a JEP should be a lightweight process that doesn’t cause friction for the contributor.
 
@@ -70,18 +70,18 @@ In order to transition out of the pre-proposal stage, the following checklist mu
 
    2. Suggested review team (optional)
 
-   3. Why it should be a JEP 
+   3. Why it should be a JEP
 
    4. 1. See the “JEP / Not-a-JEP Rubric” below.
 3. A *Shepherd* is identified to see the process through. (Shepherds are assigned on a round-robin basis from a set of interested engaged volunteers).
 4. A number is assigned to the JEP to track it through the rest of the process.
 
-Outcome: 
+Outcome:
 
 The Shepard decides if the JEP criteria have been met.
 
-- *It's a JEP! Please create a new PR with the JEP contents using template X.  On that basis, you can resolve this issue unless you have further questions.*
-- It’s not a JEP. (Provide reasons and close the issue.)
+- *It's a JEP!* Please create a new PR with the JEP contents using template X.  On that basis, you can resolve this issue unless you have further questions.*
+- *It’s not a JEP*. (Provide reasons and close the issue.)
 
 ### Phase 2: RFC for the JEP
 
@@ -125,7 +125,19 @@ This section contains a list of principles and scenarios that can be used to hel
 - - Sandboxed cell outputs
 - The proposal involve creating a new repository or subproject?
 
-### Glossary
+## Distribution
+
+This section describes how information about the JEP process (e.g., new JEPs, updates to
+current JEPs, etc) is communicated to the community.
+
+### The JEP public archive website
+
+A list of all current JEPs and the content present in the pull request exists at
+the JEP text, all relevant metadata about the JEP, and links to PRs and issues
+for the JEP. When a JEP enters into a final state (e.g., "Completed",
+"Withdrawn", "Rejected"), it is added to this website.
+
+## Glossary
 
 - Jupyter Enhancement Proposal (JEP): A written document that describes a proposed unit of significant work on Jupyter.
 
@@ -139,7 +151,7 @@ This section contains a list of principles and scenarios that can be used to hel
 
 - JEP Status:
 
-- - Inactive
+  - Inactive
   - Submitted
   - Assigned
   - Rejected

--- a/29-jep-process/README.md
+++ b/29-jep-process/README.md
@@ -14,7 +14,7 @@ Project Jupyter has an existing repository and process for “Jupyter Enhancemen
 
 <https://github.com/jupyter/enhancement-proposals>
 
-This format was originally used by IPython (IPEP) and continues to be used by the Python Core language (PEP). As currently envisioned, JEPs are written documents, in the form of a Pull Request to this repo, which describes significant proposed units of work on the projects. The README of the repo summarizes this as:
+This format was originally used by [IPython (IPEP)](https://github.com/ipython/ipython/wiki/IPEPs:-IPython-Enhancement-Proposals) and continues to be used by the [Python Core language (PEP)](https://www.python.org/dev/peps/). As currently envisioned, JEPs are written documents, in the form of a Pull Request to this repo, which describes significant proposed units of work on the projects. The README of the repo summarizes this as:
 
 “Jupyter Enhancement Proposals will be used when presenting changes or additions that affect multiple components of the Jupyter ecosystem OR changes to a single key component.”
 
@@ -44,13 +44,13 @@ With that in mind, the JEP process operates under the following tenets:
 
 - **The JEP process naturally complements the PR process, but does not replace it.**  A thoroughly-reviewed and approved JEP is a valuable reference during a PR to reduce friction, reduce time-consuming context sharing, and encapsulate decisions and other discussions.  Moving a premature PR into a JEP should be a lightweight process that doesn’t cause friction for the contributor.
 
-- - GitHub issue and PR templates, for example, across the entire Jupyter project, should have references to the JEP process as a possible outcome of a given PR.
+  - GitHub issue and PR templates, for example, across the entire Jupyter project, should have references to the JEP process as a possible outcome of a given PR.
 
 - **There is one JEP repository, all Jupyter-governed projects must use it.**  To faciliate the easiest possible adoption and high visibility of ideas, a single JEP repository will be used.  Even if a JEP only applies to a single organization.
 
 - The JEP process **has multiple valid use cases**.  Each use case might have a slightly different expected workflow or base JEP template.  Some expected use cases include:
 
-- - Non-trivial feature proposals within a single component that would benefit from process.  (e.g., a non-trivial change to JupyterLab that would benefit from formal process within the JupyterLab project)
+  - Non-trivial feature proposals within a single component that would benefit from process.  (e.g., a non-trivial change to JupyterLab that would benefit from formal process within the JupyterLab project)
   - Non-trivial features or improvements that span multiple projects.
   - Any proposed changes to published APIs or core specifications (e.g., nbformat)
   - Changes to the JEP process itself.
@@ -112,18 +112,21 @@ If in the course of the implementation, the implementer(s) can choose to withdra
 
 This section contains a list of principles and scenarios that can be used to help define a set of principles for determining when something is a JEP. The principles will be used both to determine when something becomes a PR during the JEP pre-proposal stage, as well as to determine when a PR becomes a JEP at an individual repo level.
 
-**Principles (If yes, Requires a JEP)**
+**Principles to follow**
+
+Below are a few example guidelines to follow when deciding if an idea should include
+a JEP (If yes, it requires a JEP). Under each question is a relevant example proposal.
 
 - Does the proposal/implementation require PRs across multiple orgs?
-- - Defining a unique cell identifier
+  - Defining a unique cell identifier
 - Does the proposal/implementation PR impact multiple orgs, or have widespread community impact?
-- - Updating nbformat
+  - Updating nbformat
 - Does the proposal/implementation change an invariant in one or more orgs?
-- - Defining a unique cell identifier
+  - Defining a unique cell identifier
   - Deferred kernel startup
 - Does the proposal/implementation create a new concept that will impact multiple repositories?
-- - Sandboxed cell outputs
-- The proposal involve creating a new repository or subproject?
+  - Sandboxed cell outputs
+- Does the proposal involve creating a new repository or subproject?
 
 ## Distribution
 
@@ -139,17 +142,17 @@ for the JEP. When a JEP enters into a final state (e.g., "Completed",
 
 ## Glossary
 
-- Jupyter Enhancement Proposal (JEP): A written document that describes a proposed unit of significant work on Jupyter.
+- **Jupyter Enhancement Proposal (JEP)**: A written document that describes a proposed unit of significant work on Jupyter.
 
-- Contributor: The person who is submitting the JEP, and might but not necessarily also have intention on organizing the implementation if so approved.
+- **Contributor**: The person who is submitting the JEP, and might but not necessarily also have intention on organizing the implementation if so approved.
 
-- Shepherd: A senior Jupyter contributor that manages the pre-proposal, submission, review, approval process of a JEP.
+- **Shepherd**: A senior Jupyter contributor that manages the pre-proposal, submission, review, approval process of a JEP.
 
-- Review Team (RT): A group of Jupyter contributors, with expertise in a particular area of the project that reviews and approves JEPs related to that area.
+- **Review Team (RT)**: A group of Jupyter contributors, with expertise in a particular area of the project that reviews and approves JEPs related to that area.
 
-- Final Comment Period (FCP): A finite-time, post-approval period for the community to make final comments.
+- **Final Comment Period (FCP)**: A finite-time, post-approval period for the community to make final comments.
 
-- JEP Status:
+- JEP Statuses:
 
   - Inactive
   - Submitted

--- a/29-jep-process/README.md
+++ b/29-jep-process/README.md
@@ -78,7 +78,7 @@ In order to transition out of the pre-proposal stage, the following checklist mu
 
 Outcome:
 
-The Shepard decides if the JEP criteria have been met.
+The Shepherd decides if the JEP criteria have been met.
 
 - *It's a JEP!* Please create a new PR with the JEP contents using template X.  On that basis, you can resolve this issue unless you have further questions.*
 - *It’s not a JEP*. (Provide reasons and close the issue.)
@@ -133,6 +133,8 @@ a JEP (If yes, it requires a JEP). Under each question is a relevant example pro
 This section describes how information about the JEP process (e.g., new JEPs, updates to
 current JEPs, etc) is communicated to the community.
 
+Note: This JEP repo is the **canonical "source of truth"** for individual JEPs, the JEP process, and activity on JEPs. 
+
 ### The JEP public archive website
 
 A list of all current JEPs and the content present in the pull request exists at
@@ -144,11 +146,11 @@ for the JEP. When a JEP enters into a final state (e.g., "Completed",
 
 - **Jupyter Enhancement Proposal (JEP)**: A written document that describes a proposed unit of significant work on Jupyter.
 
-- **Contributor**: The person who is submitting the JEP, and might but not necessarily also have intention on organizing the implementation if so approved.
+- **Contributor**: The person (or persons) who is submitting the JEP. The implementation of a JEP may be done by others if so approved.
 
-- **Shepherd**: A senior Jupyter contributor that manages the pre-proposal, submission, review, approval process of a JEP.
+- **Shepherd**: A senior Jupyter contributor who guides the **JEP Contributor** through the pre-proposal, submission, review, approval process of a JEP.
 
-- **Review Team (RT)**: A group of Jupyter contributors, with expertise in a particular area of the project that reviews and approves JEPs related to that area.
+- **Review Team (RT)**: A group of Jupyter contributors, with expertise in a particular area of the project, that reviews JEPs related to that area.
 
 - **Final Comment Period (FCP)**: A finite-time, post-approval period for the community to make final comments.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Below is a list of JEPs that have been submitted. To view the discussion around 
 | 0025 | Completed | [Enterprise Gateway](https://github.com/jupyter/enhancement-proposals/pull/25) |
 | 0026 | **Submitted** | [Add Language Server Support to Jupyter Server and jupyterlab-monaco](https://github.com/jupyter/enhancement-proposals/pull/26) |
 | 0028 | **Submitted** | [Standalone Jupyter Server](https://github.com/jupyter/enhancement-proposals/pull/28) |
-
+| 0029 | **Submitted** | [Jupyter Enhancement Proposal updates](https://github.com/jupyter/enhancement-proposals/pull/29)
 
 ## How do I submit a JEP?
 


### PR DESCRIPTION
Hey all - this PR builds off of #29 to add some language to the JEP enhancement proposal. There's a relevant issue to discuss this here: #27 

This PR is primarily about adding a "distribution" section to the "meta JEP". It mentions using a public website as an "archive" of finished JEPs. I tried not to tie it in to any specific technology, since I feel like that is more of an implementation detail and we can cross that bridge when we come to it. Hope that's OK.

The PR also:

* Cleans up a few formatting things I found in there, and adds links to the ipython/python *EP process
* Adds this JEP to the list of active JEPs in the readme (I am a bit unclear that status this JEP has...so I just left what was in the metadata for this one)

Lemme know what folks think!