### PR TITLE
Fix JEP state in header

### DIFF
--- a/29-jep-process/README.md
+++ b/29-jep-process/README.md
@@ -3,7 +3,7 @@
 | JEP number | 29                                                           |
 | Title      | Jupyter Enhancement Proposal                                 |
 | Authors    | Jason Grout ([jason@jasongrout.org](mailto:jason@jasongrout.org)), Safia Abdalla ([safia@safia.rocks](mailto:safia@safia.rocks)), John Lam ([jflam@microsoft.com](mailto:jflam@microsoft.com)), Kevin M. McCormick ([mckev@amazon.com](mailto:mckev@amazon.com)), Pierre Brunelle ([brunep@amazon.com](mailto:brunep@amazon.com)), Paul Ivanov ([pi@berkeley.edu](mailto:pi@berkeley.edu)) |
-| Status     | Submitted                                                    |
+| Status     | Draft                                                   |
 | Type       | P - Process                                                  |
 | Created    | 23-Feb-2019                                                  |
 | History    | 04-Mar-2019                                                  |


### PR DESCRIPTION
I'm updating the header really quickly. I thought that "Submitted" was our term for a JEP in draft but I just looked at the jupyter-server JEP and the term is draft so updating it here. 