### PR TITLE
Minimal steps to add a website

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+version: 2
+jobs:
+  build_docs:
+    docker:
+      - image: circleci/python:3.6-stretch
+    steps:
+      # Get our data and merge with upstream
+      - run: sudo apt-get update
+      - checkout
+
+      - restore_cache:
+          keys:
+            - cache-pip
+
+      - run: |
+          pip install jupyter-book
+      - save_cache:
+          key: cache-pip
+          paths:
+            - ~/.cache/pip
+
+      # Build the docs
+      - run:
+          name: Build docs to store
+          command: |
+            jb build .
+
+      - store_artifacts:
+          path: _build/html/
+          destination: html
+
+
+workflows:
+  version: 2
+  default:
+    jobs:
+      - build_docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,37 @@
+name: deploy-book
+
+# Only run this when the master branch changes
+on:
+  push:
+    branches:
+    - master
+
+# This job installs dependencies, build the book, and pushes it to `gh-pages`
+jobs:
+  deploy-book:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # Install dependencies
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+
+    - name: Install dependencies
+      run: |
+        pip install -U jupyter-book
+
+
+    # Build the book
+    - name: Build the book
+      run: |
+        jupyter-book build .
+
+    # Push the book's HTML to github-pages
+    - name: GitHub Pages action
+      uses: peaceiris/actions-gh-pages@v3.5.9
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./_build/html

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+# Jupyter Book
+_build

--- a/28-jupyter-server/jupyter-server.md
+++ b/28-jupyter-server/jupyter-server.md
@@ -1,14 +1,13 @@
-# Standalone Jupyter server enhancement proposal [active]
+---
+title: Standalone Jupyter server
+authors: Zach Sailer ([@Zsailer](https://github.com/Zsailer)) and Sylvain Corlay ([@SylvainCorlay](https://github.com/sylvaincorlay))
+issue-number: 31
+pr-number: 28
+date-started: "2016-09-20"
+type: S - [Standards Track](https://www.python.org/dev/peps/#pep-types-key)
+---
 
-| Item       | Value                                                                                                                        |
-|------------|------------------------------------------------------------------------------------------------------------------------------|
-| JEP Number | 10                                                                                                                           |
-| Title      | Standalone Jupyter Server                                                                                                    |
-| Authors    | Zach Sailer ([@Zsailer](https://github.com/Zsailer)) and Sylvain Corlay ([@SylvainCorlay](https://github.com/sylvaincorlay)) |
-| Status     | Draft                                                                                                                        |
-| Type       | S - [Standards Track](https://www.python.org/dev/peps/#pep-types-key) JEP                                                    |
-| Created    | 20 September 2016                                                                                                            |
-| History    | 20 September 2016, 12 February 2019                                                                                          |
+# Standalone Jupyter server enhancement
 
 ## Problem
 
@@ -19,7 +18,7 @@ There are now multiple frontends that talk to the backend services provided by t
 Decouple the backend server (and its configuration) from the classic notebook frontend. This will require the following steps:
 
 1. [Separate `jupyter_server` repository](#separate-jupyter_server-repository)
-    - A fork of the `notebook` repository. 
+    - A fork of the `notebook` repository.
     - Pure Python package with notebook backend services.
     - `notebook` tornado handlers and frontend logic stay in `notebook` repo.
     - Deprecated notebook server APIs do not move to `jupyter_server`.
@@ -29,12 +28,12 @@ Decouple the backend server (and its configuration) from the classic notebook fr
 1. [Extensions as Applications](#extensions-as-applications)
     - server extensions move to `jupyter_server`.
     - New `ExtensionApp` class
-    - Notebook, jupyterlab, etc. become ExtensionApps. 
+    - Notebook, jupyterlab, etc. become ExtensionApps.
 1. [New server extensions mechanism.](#new-server-extensions-mechanism)
-    - new base classes to create applications from server extensions. 
-    - nbextensions stay in `notebook`. 
+    - new base classes to create applications from server extensions.
+    - nbextensions stay in `notebook`.
     - `jupyter_notebook_config.d` folder becomes `jupyter_server_config.d`
-1. [Namespacing static files and REST API urls.](#add-namespacing-to-static-endpoints-and-rest-api-urls) 
+1. [Namespacing static files and REST API urls.](#add-namespacing-to-static-endpoints-and-rest-api-urls)
     - Each extension serves static files at the `/static/<extension>` url.
     - New `ExtensionHandlerApp` class
 1. [Configuration System](#configuration-system)
@@ -45,7 +44,7 @@ Decouple the backend server (and its configuration) from the classic notebook fr
 ### Separate `jupyter_server` repository
 
 The first thing to do is fork `notebook`. A new `jupyter_server` repo will keep the server specific logic and remove:
-1. the notebook frontend code, 
+1. the notebook frontend code,
 2. deprecated notebook server APIs, and
 3. tornado handlers to the classic notebook interface. These pieces will stay in the `notebook` repository.
 
@@ -74,11 +73,11 @@ Preliminary work resides in [jupyter_server](https://github.com/jupyter/jupyter_
 
 The server-notebook split is an opportunity to clearly define Jupyter's core services. The old notebook server was comprised of many services, and it could be extended by separate "server extensions". However, it isn't clear what should be a core service versus a server extension. Some extensions were "grand-fathered" in as core services to make the notebook application more full-featured (e.g. nbconvert, terminals, contents, ...). Now that we are separating the server from the classic notebook, we need to reevaluate what services are core to the Jupyter Server.
 
-Jupyter server aims to be a core building block for other applications (like nteract, lab, dashboards, standalone widgets, etc.). To achieve this, we need to define the simplest "unit" that defines a Jupyter Server: `kernels`, `kernelspec`, and `sessions`. Other services become extensions to the core server (using the `load_jupyter_server_extension` mechanism defined below). 
+Jupyter server aims to be a core building block for other applications (like nteract, lab, dashboards, standalone widgets, etc.). To achieve this, we need to define the simplest "unit" that defines a Jupyter Server: `kernels`, `kernelspec`, and `sessions`. Other services become extensions to the core server (using the `load_jupyter_server_extension` mechanism defined below).
 
 ### Extensions as Applications
 
-A new `ExtensionApp` class will be available in `jupyter_server.extensions.extensionapp`. It enables developers to make server extensions behave like standalone Jupyter applications. Jupyterlab is an example of this kind of server extension. It can be configured, initialized, and launched from the command line. When Lab is launched, it first initializes and configures a jupyter (notebook) server, then loads the configured jupyterlab extension and redirects the use to the Lab landing page.  
+A new `ExtensionApp` class will be available in `jupyter_server.extensions.extensionapp`. It enables developers to make server extensions behave like standalone Jupyter applications. Jupyterlab is an example of this kind of server extension. It can be configured, initialized, and launched from the command line. When Lab is launched, it first initializes and configures a jupyter (notebook) server, then loads the configured jupyterlab extension and redirects the use to the Lab landing page.
 
 `ExtensionApp` handles the boilerplate code to make Jupyter applications that configure and launch server extensions directly. It inherits `jupyter_core.JupyterApp` and exposes a command line entry point: `jupyter <extension-name>`. When an extension is launched, it first configures and starts a jupyter_server (`ServerApp`); then, it loads the configured extension and redirects users to the extension's landing page. Extension developers simply inherit the `ExtensionApp` and add the extension's `load_jupyter_server_extension` as a `staticmethod`.
 
@@ -93,7 +92,7 @@ class MyExtension(ExtensionApp):
     load_jupyter_server_extension = staticmethod(load_jupyter_server_extension)
 ```
 
-`ExtensionApp`s can be configured by `jupyter_<extension-name>_config.py|json` as well. When the server extension is loaded by a server or launched from the command line, it searches the list of `jupyter --paths` for configured traits in these files. 
+`ExtensionApp`s can be configured by `jupyter_<extension-name>_config.py|json` as well. When the server extension is loaded by a server or launched from the command line, it searches the list of `jupyter --paths` for configured traits in these files.
 
 Initial experimental work resides in [`jupyter_server_extension`](https://github.com/Zsailer/jupyter_server_extension).
 
@@ -105,13 +104,13 @@ c.ServerApp.jpserver_extensions = {
     'notebook': True
 }
 ```
-Users can also launch the notebook application using the (usual)`jupyter notebook` command line interface. 
+Users can also launch the notebook application using the (usual)`jupyter notebook` command line interface.
 
 ### New server extensions mechanism.
 
 The new extension mechanism in the *jupyter server* will differ from notebook's server extensions.
 
-* The `--sys-prefix` installation would become the default. (Users are confused when enabling an extension requires more permissions than the installation of the package). Installation in system-wide directories would be done with the `--system` option. 
+* The `--sys-prefix` installation would become the default. (Users are confused when enabling an extension requires more permissions than the installation of the package). Installation in system-wide directories would be done with the `--system` option.
 * Installing an extension will include the addition of a 'manifest' file into a conf.d directory (under one of the Jupyter configuration directories, `user / sys-prefix / system`). The placement of such an extension manifest provided by a Python package can be done with `jupyter server extension install --py packagename [--user / --system / --sys-prefix]`. Packages (conda or wheels) carrying server extensions could place such manifests in the sys-prefix path by default effectively installing them. Development installations would also require the call to the installation command.
 
 * Enabling an extension is separate from the installation. Multiple scenarios are possible:
@@ -119,7 +118,7 @@ The new extension mechanism in the *jupyter server* will differ from notebook's 
   - forcibly disabling an extension that was enabled at a lower level of precedence.
   - forcibly enabling an extension that was disabled at a lower level of precedence.
   This would be done via two `conf.d` configuration directories managing a list of disabled extensions and list of enabled extensions in the form of empty files having the name of the corresponding extension. If an extension is both disabled and enabled at the same level of precedence, disabling has precedence. Packages (conda or wheels) could place such a enabler file in the sys-prefix path by default. The `jupyter server extension enable` command would be required for development installations.
-  
+
 (Possibly) when an extension is enabled at a given precedence level, it may only look for the version of the extension installed at the same or lower precedence level. For example, if an extension `foobar` is installed and enabled system wide, but a user installs a version with `--user`, this version will only be picked up if the user also enables it with `--user`.
 
 ### Add namespacing to `static` endpoints and REST API urls.
@@ -136,32 +135,32 @@ Preliminary experimental work resides in the [`jupyter_server_extension`](https:
 
 Splitting the server-specific pieces from the classic notebook affects Jupyter's configuration system. This is a non-trivial problem. Changing Jupyter's configuration system affects everyone. We need to consider how to make this transition as painless as possible. At the end of this section, we list some steps that make reduce the friction.
 
-Here is a list of things the changes on the configuration system: 
+Here is a list of things the changes on the configuration system:
 * Move server-specific configuration from `jupyter_notebook_config.py|json` into `jupyter_server_config.py|json`.
 * Notebook configuration will stay in `jupyter_notebook_config.py|json`.
 * Server extensions configurations move from `jupyter_notebok_config.d` to `jupyter_server_config.d`.
 * The tornado server and webapp configurable applications move to `jupyter_server`. They become `ServerApplication` and `ServerWebApp`
 * The `NotebookApp` becomes a server extension. It would only load notebook specific configuration/traitlets, from `jupyter_notebook_config.py|json`.
-* Server extensions are found using the `jpserver_extensions` trait instead of the `nbserver_extensions` trait in the `ServerApp`. 
+* Server extensions are found using the `jpserver_extensions` trait instead of the `nbserver_extensions` trait in the `ServerApp`.
 * Extension configuration files in `jupyter_server_config.d` must be enabled using the `jpserver_extensions` trait. They are enabled by JSON config files in `jupyter_server_config.d`.
 * Extensions can create their own configuration files in `{sys-prefix}/etc/jupyter/` or `~/.jupyter`, i.e. `jupyter_<my-extension>_config.py|json`.
 * General `jupyter_config.py|json` files must update to set server-specific configuration using the `ServerApp` and notebook specific configuration using `NotebookApp`.
 
 Some traits will stay in `jupyter_notebook_config.py|json`. Here is a list of those traits (everything else moves to server config files):
-* extra_nbextensions_path 
-* enable_mathjax 
-* max_body_size 
-* max_buffer_size 
-* notebook_dir 
-* mathjax_url 
-* get_secure_cookie_kwargs 
-* mathjax_config 
+* extra_nbextensions_path
+* enable_mathjax
+* max_body_size
+* max_buffer_size
+* notebook_dir
+* mathjax_url
+* get_secure_cookie_kwargs
+* mathjax_config
 * ignore_minified_js
 
 Here are some steps we can take to reduce the friction for transitioning:
 * **Copy (not move)** `jupyter_notebook_config.py|json` to `jupyter_server_config.py|json`
 * **Copy (not move)** `jupyter_notebook_config.d/` to `jupyter_server_config.d`.
-* `NotebookApp` becomes `ServerApp` in all copied files. 
+* `NotebookApp` becomes `ServerApp` in all copied files.
 * Leftover server traits in `jupyter_notebook_config.py|json` get ignored when the notebook extension is initialized. Server traits are only read from `jupyter_server_config.py|json`.
 * Document like crazy!
 
@@ -173,17 +172,18 @@ To make migration easier on users, a `migrate` application will be available to 
 
 ### How this effects other projects
 
-[**Classic notebook**]()
+**Classic notebook**
 In short, the classic notebook will become a server extension application. The rest of this proposal describes the details behind what will change in the notebook repo.
-[`JupyterServerExtensionApp`](). 
 
-[**Jupyter Lab**]()
+`JupyterServerExtensionApp`
+
+**Jupyter Lab**
 Jupyter lab will also become a server extension application. The new classes described above should simplify the way JupyterLab interfaces with the server.
 
-[**Kernel Gateway**]()
-Kernel Gateway can use the new Jupyter Server to server kernels as a service. The new Jupyter server will remove the unwanted services that Kernel Gateway currently removes by using a custom server application. KG will also be able to swap out the kernels and kernelspec manager in the Jupyter Server with its custom classes. 
+**Kernel Gateway**
+Kernel Gateway can use the new Jupyter Server to server kernels as a service. The new Jupyter server will remove the unwanted services that Kernel Gateway currently removes by using a custom server application. KG will also be able to swap out the kernels and kernelspec manager in the Jupyter Server with its custom classes.
 
-[**Kernel Nanny**]()
+**Kernel Nanny**
 
 ## Pros and Cons
 
@@ -198,7 +198,7 @@ Kernel Gateway can use the new Jupyter Server to server kernels as a service. Th
 
 * Break the classic notebook in a backwards incompatible way.
 * Affects many projects. The transition may be painful?
-* Adding a dependency injection system adds new complexity. 
+* Adding a dependency injection system adds new complexity.
 
 ## Relevent Issues, PRs, and discussion
 

--- a/29-jep-process/jep-process.md
+++ b/29-jep-process/jep-process.md
@@ -1,14 +1,16 @@
-| Item       | Value                                                        |
-| ---------- | ------------------------------------------------------------ |
-| JEP number | 29                                                           |
-| Title      | Jupyter Enhancement Proposal                                 |
-| Authors    | Jason Grout ([jason@jasongrout.org](mailto:jason@jasongrout.org)), Safia Abdalla ([safia@safia.rocks](mailto:safia@safia.rocks)), John Lam ([jflam@microsoft.com](mailto:jflam@microsoft.com)), Kevin M. McCormick ([mckev@amazon.com](mailto:mckev@amazon.com)), Pierre Brunelle ([brunep@amazon.com](mailto:brunep@amazon.com)), Paul Ivanov ([pi@berkeley.edu](mailto:pi@berkeley.edu)) |
-| Status     | Draft                                                   |
-| Type       | P - Process                                                  |
-| Created    | 23-Feb-2019                                                  |
-| History    | 04-Mar-2019, 07-Mar-2019                                                  |
+---
+title: Jupyter Enhancement Proposal
+authors: |
+  Jason Grout ([jason@jasongrout.org](mailto:jason@jasongrout.org)), Safia Abdalla ([safia@safia.rocks](mailto:safia@safia.rocks)), John Lam ([jflam@microsoft.com](mailto:jflam@microsoft.com)), Kevin M. McCormick ([mckev@amazon.com](mailto:mckev@amazon.com)), Pierre Brunelle ([brunep@amazon.com](mailto:brunep@amazon.com)), Paul Ivanov ([pi@berkeley.edu](mailto:pi@berkeley.edu))
+issue-number: 27
+pr-number: 29
+date-started: "2019-02-23"
+type: P - Process
+---
 
-### Background
+# Jupyter Enhancement Proposal
+
+## Background
 
 Project Jupyter has an existing repository and process for “Jupyter Enhancement Proposals” or JEP for short. The repository is here:
 

--- a/42-voila-incorporation/voila-incorporation.md
+++ b/42-voila-incorporation/voila-incorporation.md
@@ -1,4 +1,13 @@
-# Voilà Incorporation Proposal
+---
+title: Voilà Incorporation
+authors: SylvainCorlay
+issue-number: XX
+pr-number: 42
+date-started: "2019-10-14"
+type: S - [Standards Track](https://www.python.org/dev/peps/#pep-types-key)
+---
+
+# Voilà Incorporation
 
 ## Problem
 

--- a/44-xeus-incorporation/xeus-incorporation.md
+++ b/44-xeus-incorporation/xeus-incorporation.md
@@ -1,10 +1,18 @@
-# Xeus Incorporation Proposal
+---
+title: Xeus Incorporation
+authors: SylvainCorlay
+issue-number: XX
+pr-number: 44
+date-started: "2019-11-30"
+---
+
+# Xeus Incorporation
 
 ## Problem
 
 The [Xeus](https://github.com/QuantStack/xeus/) project is a C++ implementation of the [Jupyter kernel protocol](https://jupyter-client.readthedocs.io/en/stable/messaging.html). Xeus is not a kernel, but a library meant to facilitate the authoring of kernels.
 
-Several Jupyter kernels have been created with Xeus: 
+Several Jupyter kernels have been created with Xeus:
 
  - [xeus-cling](https://github.com/QuantStack/xeus-cling), a kernel for the C++ programming language, based on the Cling C++ interpreter. The [cling](https://github.com/root-project/cling) project comes from CERN and is at the foundation of the [ROOT](https://github.com/root-project/root.git) project.
  - [xeus-python](https://github.com/QuantStack/xeus-python), a kernel for the Python programming language, embedding the Python interpreter.

--- a/README.md
+++ b/README.md
@@ -12,21 +12,22 @@ Below is a list of JEPs that have been submitted. To view the discussion around 
 |--------|--------|-------|
 | 0004   | Inactive | [New Notebook Format for improved workflow integration](https://github.com/jupyter/enhancement-proposals/pull/4) |
 | 0007   | Inactive | [Jupyter Extension Generator](https://github.com/jupyter/enhancement-proposals/pull/7) |
-| 0008 | Completed | [Diffing and Merging Notebooks](https://github.com/jupyter/enhancement-proposals/pull/8) |
-| 0012 | Completed | [Kernel Gateway](https://github.com/jupyter/enhancement-proposals/pull/12) |
+| 0008 | Implemented | [Diffing and Merging Notebooks](https://github.com/jupyter/enhancement-proposals/pull/8) |
+| 0012 | Implemented | [Kernel Gateway](https://github.com/jupyter/enhancement-proposals/pull/12) |
 | 0014 | **Submitted** | [Kernel Nanny](https://github.com/jupyter/enhancement-proposals/pull/14) |
 | 0015 | Withdrawn | [Layout Namespaces and Discovery](https://github.com/jupyter/enhancement-proposals/pull/15) |
 | 0016 | **Submitted** | [Notebook Translation and Localization](https://github.com/jupyter/enhancement-proposals/pull/16) |
-| 0017 | Completed | [Dashboards Notebook Extension](https://github.com/jupyter/enhancement-proposals/pull/17) |
-| 0018 | Completed | [Declarative Widgets Extension](https://github.com/jupyter/enhancement-proposals/pull/18) |
-| 0022 | Completed | [Move Dashboards Deployment Projects from Incubator to Attic](https://github.com/jupyter/enhancement-proposals/pull/22) |
+| 0017 | Implemented | [Dashboards Notebook Extension](https://github.com/jupyter/enhancement-proposals/pull/17) |
+| 0018 | Implemented | [Declarative Widgets Extension](https://github.com/jupyter/enhancement-proposals/pull/18) |
+| 0022 | Implemented | [Move Dashboards Deployment Projects from Incubator to Attic](https://github.com/jupyter/enhancement-proposals/pull/22) |
 | 0023 | **Submitted** | [Jupyter Template as Metadata](https://github.com/jupyter/enhancement-proposals/pull/23) |
 | 0024 | **Submitted** | [Simplifying Error Reporting in Jupyter Protocol](https://github.com/jupyter/enhancement-proposals/pull/24) |
-| 0025 | Completed | [Enterprise Gateway](https://github.com/jupyter/enhancement-proposals/pull/25) |
+| 0025 | Implemented | [Enterprise Gateway](https://github.com/jupyter/enhancement-proposals/pull/25) |
 | 0026 | **Submitted** | [Add Language Server Support to Jupyter Server and jupyterlab-monaco](https://github.com/jupyter/enhancement-proposals/pull/26) |
 | 0028 | **Submitted** | [Standalone Jupyter Server](https://github.com/jupyter/enhancement-proposals/pull/28) |
 | 0029 | **Accepted** | [Jupyter Enhancement Proposal updates](https://github.com/jupyter/enhancement-proposals/pull/29)
 | 0042 | **Accepted** | [Voila Incorporation](https://github.com/jupyter/enhancement-proposals/pull/42)
+| 0044 | **Accepted** | [Xeus Incorporation](https://github.com/jupyter/enhancement-proposals/pull/44)
 
 ## How do I submit a JEP?
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,14 @@
+title                       : Jupyter Enhancement Proposals
+author                      : Project Jupyter
+copyright                   : "2020"
+exclude_patterns            : ["LICENSE.md", ".github"]
+home_page_in_navbar         : false
+
+repository:
+  url: https://github.com/jupyter/enhancement-proposals
+  branch: master
+
+html:
+  use_repository_button: true
+  use_issues_button: true
+  use_edit_page_button: true

--- a/_toc.yml
+++ b/_toc.yml
@@ -1,0 +1,13 @@
+file: README
+sections:
+- file: 44-xeus-incorporation/xeus-incorporation
+- file: 42-voila-incorporation/voila-incorporation
+- file: 29-jep-process/jep-process
+- file: 28-jupyter-server/jupyter-server
+- file: jupyter-dashboards-deployment-attic/jupyter-dashboards-deployment-attic
+- file: jupyter-dashboards-extension-incorporation/jupyter-dashboards-extension-incorporation
+- file: jupyter-declarativewidgets-incorporation/jupyter-declarativewidgets-extension-incorporation
+- file: jupyter-enhancement-proposal-guidelines/jupyter-enhancement-proposal-guidelines
+- file: jupyter-enterprise-gateway-incorporation/jupyter-enterprise-gateway-incorporation
+- file: jupyter-kernel-gateway-incorporation/jupyter-kernel-gateway-incorporation
+- file: notebook-diff/notebook-diff

--- a/jupyter-dashboards-deployment-attic/jupyter-dashboards-deployment-attic.md
+++ b/jupyter-dashboards-deployment-attic/jupyter-dashboards-deployment-attic.md
@@ -1,4 +1,4 @@
-# Proposal to Move the Jupyter Dashboards Deployment Projects from Incubator to Attic
+# Move the Jupyter Dashboards Deployment Projects from Incubator to Attic
 
 ## Problem
 
@@ -23,25 +23,25 @@ We should use the remainder of this document to capture:
 
 The [Jupyter Governance - New Subproject Process](https://github.com/jupyter/governance/blob/master/newsubprojects.md) lists eight criteria used to evaluate projects for incorporation into one of the official Jupyter organizations. The dashboard deployment projects have been failing to meet at least five of these criteria for some time.
 
-#### Have an active developer community that offers a sustainable model for future development.
+### Have an active developer community that offers a sustainable model for future development.
 
 Members of the original development team have moved on from the project for a variety of reasons. While developers from the broader Jupyter community have opened a handful of pull requests (PRs) over the past year, there are no active maintainers who review PRs, respond to issues, upgrade components, maintain compatibility with other Jupyter projects, write documentation, fix failing tests, and so on.
 
-#### Have an active user community.
+### Have an active user community.
 
 There is [certainly user interest](https://github.com/jupyter-incubator/dashboards_server/issues/319) in a dashboard deployment solution for Jupyter notebooks. However, users who have tried the deployment projects [have met with limited success](https://github.com/jupyter-incubator/dashboards_server/issues) given the current complexity of [running the full project stack](https://github.com/jupyter/dashboards/wiki#get-started) due to lack of work on making it easier over the past year.
 
-#### Demonstrate continued growth and development.
+### Demonstrate continued growth and development.
 
 Development of new features has ceased. The original project roadmap ends at the current feature set and calls for work to continue on ["how dashboarding features materialize in JupyterLab."](https://github.com/jupyter/dashboards/wiki/Deployment-Roadmap#may-2016-update).
 
-#### Integrate well with other official Subprojects.
+### Integrate well with other official Subprojects.
 
 The [dashboards layout extension](https://github.com/jupyter/dashboards) defines a [notebook metadata format](http://jupyter-dashboards-layout.readthedocs.io/en/latest/metadata.html) and uses it to persist information about on-screen notebook cell arrangements. The dashboard deployment projects depend on this metadata. No other Jupyter projects support it.
 
 Conversely, the dashboard deployment projects use ipywidgets and various JupyterLab components for interactivity and rendering. These two libraries have undergone major development over the past year as they've matured. The dashboard deployment projects have not kept pace, and currently rely on [back-level versions](https://github.com/jupyter-incubator/dashboards_server/blob/master/package.json#L48).
 
-#### Have a well-defined scope.
+### Have a well-defined scope.
 
 The [dashboards incubator proposal](https://github.com/jupyter-incubator/proposals/blob/master/dashboards/proposal.md#scope) includes a section concerning project scope. The stated objective of "establish[ing] a baseline prototype that demonstrates how notebook authors can publish dashboards" is not, however, clearly documented outside the proposal nor refined in response to [evolving technical constraints](https://github.com/jupyter-incubator/dashboards_server/issues/302). Users are left guessing about the scope of "dashboard deployment" supported by the projects.
 

--- a/jupyter-dashboards-extension-incorporation/jupyter-dashboards-extension-incorporation.md
+++ b/jupyter-dashboards-extension-incorporation/jupyter-dashboards-extension-incorporation.md
@@ -1,4 +1,4 @@
-# Jupyter Dashboards Extension Incorporation Proposal
+# Jupyter Dashboards Extension Incorporation
 
 ## Problem
 
@@ -57,7 +57,7 @@ The ["What It Gives You" section of the project README](https://github.com/jupyt
 
 The dashboards extension is a pure JavaScript extension for the Jupyter Notebook frontend. It adds a toolbar and menu items for switching between three views: notebook, dashboard layout, and dashboard preview. It also adds a set of menu items for quickly adding/removing all cells to/from the dashboard layout. Help for creating dashboard layouts appears in situ in the layout mode.
 
-The extension currently supports two types of layout: grid and report. The user moves, resizes, and shows/hides notebook cell widgets/outputs in a responsive grid in the former. The user simply shows/hides cell widgets/outputs in top-down notebook order in the latter. The extension [persists information about the layouts within the notebook document](https://github.com/jupyter-incubator/dashboards/wiki/Dashboard-Metadata-and-Rendering). 
+The extension currently supports two types of layout: grid and report. The user moves, resizes, and shows/hides notebook cell widgets/outputs in a responsive grid in the former. The user simply shows/hides cell widgets/outputs in top-down notebook order in the latter. The extension [persists information about the layouts within the notebook document](https://github.com/jupyter-incubator/dashboards/wiki/Dashboard-Metadata-and-Rendering).
 
 Both the notebook extension and the notebook document specification are extensible. They may grow support for additional kinds of layout in the future (e.g., fixed grids, paged wizards).
 
@@ -114,7 +114,7 @@ The dashboards extension is packaged using setuptools, released on PyPI, and ins
 * Pro: Works with the other incubating projects to enable deployment of dashboard-notebooks as standalone web applications.
 * Pro: Defines a spec for storing layout metadata in notebook documents and steps for rendering those layouts.
 * Pro: Serves as a test bed and reference implementation for future dashboard efforts in Jupyter Lab.
-* Con: There is currently [no consensus on a light proposal](https://github.com/jupyter/enhancement-proposals/pull/15) for where to store layout metadata in notebooks, let alone a single layout metadata spec to be shared across all tools (including those beyond the dashboards use case). 
+* Con: There is currently [no consensus on a light proposal](https://github.com/jupyter/enhancement-proposals/pull/15) for where to store layout metadata in notebooks, let alone a single layout metadata spec to be shared across all tools (including those beyond the dashboards use case).
 
 ## Interested Contributors
 

--- a/jupyter-declarativewidgets-incorporation/jupyter-declarativewidgets-extension-incorporation.md
+++ b/jupyter-declarativewidgets-incorporation/jupyter-declarativewidgets-extension-incorporation.md
@@ -1,4 +1,4 @@
-# Jupyter DeclarativeWidgets Extension Incorporation Proposal
+# Jupyter DeclarativeWidgets Extension Incorporation
 
 ## Problem
 
@@ -9,7 +9,7 @@ Alice is a Jupyter Notebook user. Alice has performed some data analysis in a No
 1. Most solutions are Python specific. Other language kernels has either limiting or no available solution in place.
 2. Most solutions would require considerable development investment to make available on other language kernels. Their implementation rely heavily on kernel side code.
 3. Most solutions are bound by a close widget system and are cumbersome to extend.
-4. Layers of abstraction make debugging difficult, requiring "peeking under the hood". 
+4. Layers of abstraction make debugging difficult, requiring "peeking under the hood".
 
 Depending on what language Alice is using for her Notebook, she will experience the following potential setbacks:
 
@@ -43,7 +43,7 @@ The declarativewidgets extension supports the following use cases:
 	* pyspark
 	* Scala Spark
 	* R
-	* sparkR 
+	* sparkR
 * Installing and importing a necessary web-component into the Notebook
 * Creating a UI using HTML markup and connecting the elements using [Polymer's data binding)[https://www.polymer-project.org/1.0/docs/devguide/data-binding].
 * Reacting to changes in data on the Kernel, for example, new data arriving on a Stream.
@@ -72,7 +72,7 @@ The declarativewidgets extensions is a combination of:
 * Kernel side implementations for Python, R[[1]](#1), and Scala[[2]](#2)
 
 #### Elements
-##### Core elements 
+##### Core elements
 
 * `<urth-core-function>` - Enable binding to functions defined in the kernel
 * `<urth-core-dataframe>` - Access to read and query DataFrames
@@ -85,7 +85,7 @@ Some of the `core` elements are a combination of browser and kernel component. O
 
 ##### Viz elements
 
-There is a collection of `<urth-viz-*>` element that are pure client side and are use to display data. These elements include a table view and a variety of plots. 
+There is a collection of `<urth-viz-*>` element that are pure client side and are use to display data. These elements include a table view and a variety of plots.
 
 
 More details about the architecture can be found [here](https://github.com/jupyter-incubator/declarativewidgets/wiki). Additionally, see the [documentation](https://jupyter-incubator.github.io/declarativewidgets/docs.html).

--- a/jupyter-enhancement-proposal-guidelines/jupyter-enhancement-proposal-guidelines.md
+++ b/jupyter-enhancement-proposal-guidelines/jupyter-enhancement-proposal-guidelines.md
@@ -195,5 +195,5 @@ quick way to display them in a reading-friendly format.
 ## Background
 
 For a background of the JEP process, and recent efforts to improve it, see
-[the meta-JEP readme](../29-jep-process/README.md).
+[the meta-JEP readme](../29-jep-process/jep-process.md).
 

--- a/jupyter-enterprise-gateway-incorporation/jupyter-enterprise-gateway-incorporation.md
+++ b/jupyter-enterprise-gateway-incorporation/jupyter-enterprise-gateway-incorporation.md
@@ -1,4 +1,4 @@
-# Jupyter Enterprise Gateway Incorporation Proposal
+# Jupyter Enterprise Gateway Incorporation
 
 ## Problem
 

--- a/jupyter-kernel-gateway-incorporation/jupyter-kernel-gateway-incorporation.md
+++ b/jupyter-kernel-gateway-incorporation/jupyter-kernel-gateway-incorporation.md
@@ -1,4 +1,4 @@
-# Jupyter Kernel Gateway Incorporation Proposal
+# Jupyter Kernel Gateway Incorporation
 
 ## Problem
 
@@ -7,7 +7,7 @@ People are creating novel applications and libraries that use Jupyter kernels as
 * [pyxie](https://github.com/oreillymedia/pyxie-static) uses kernels to evaluate code from a text area on a web page
 * [Thebe](https://github.com/oreillymedia/thebe) uses kernels to evaluate code from multiple input areas on a web page
 * [gist exec](https://github.com/rgbkrk/gistexec) uses kernels to evaluate code from GitHub gists rendered as web pages
-* [Atom Notebook](github.com/jupyter/atom-notebook) uses kernels to enable a notebook experience in the Atom text editor
+* [Atom Notebook](https://github.com/jupyter/atom-notebook) uses kernels to enable a notebook experience in the Atom text editor
 * [Eclairjs](https://github.com/EclairJS/eclairjs-node) uses the Apache Toree kernel as a means of executing Apache Spark jobs defined in JavaScript
 * [Jupyter dashboard server](https://github.com/jupyter-incubator/dashboards_nodejs_app) uses kernels to evaluate code from notebooks rendered as interactive dashboards
 


### PR DESCRIPTION
This is another implementation PR of #29 - it makes minimal changes needed to get a Jupyter Book building a website from the JEPs that are here. It also does some minor re-configuration of metadata, titles, etc to make it easier to organize and parse.

It also adds a github action that will automatically build the book and push to github-pages, and the docs will be publicly available at https://jupyter.org/enhancement-proposals

Note: there are probably other things to improve here, but I wanted to take the minimal number of steps and we can always iterate in the future if people like it

Here's how it looks:

https://2-41511140-gh.circle-artifacts.com/0/html/README.html