### PR TITLE
add workflow for link checking and spelling

### DIFF
--- a/.ci_support/check_links.sh
+++ b/.ci_support/check_links.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CACHE_NAME=$(pwd)/.pytest-check-links-cache
+KNOWN_FAILS="\
+ibm \
+or declarativewidgets
+"
+
+cd _build/html
+
+
+pytest \
+  --check-links \
+  --check-links-cache \
+  --check-links-cache-name $CACHE_NAME \
+  --check-links-cache-expire-after 604800 \
+  --links-ext html \
+  -k "not ($KNOWN_FAILS)"

--- a/.ci_support/check_spelling.sh
+++ b/.ci_support/check_spelling.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "checking spelling..."
+
+cd _build/html
+
+hunspell \
+  -d en-GB,en_US \
+  -p ../../.ci_support/dictionary.txt \
+  -l \
+  -H **/*.html \
+  | sort \
+  | uniq \
+  > check-spelling.txt
+
+if [ -s "check-spelling.txt" ]; then
+  echo "hunspell found misspelled words"
+  cat check-spelling.txt
+  exit 1
+else
+  echo "hunspell did not find any misspelled words"
+fi

--- a/.ci_support/dictionary.txt
+++ b/.ci_support/dictionary.txt
@@ -1,0 +1,5 @@
+DeclarativeWidgets
+JEP
+Jupyter
+Xeus
+md

--- a/.ci_support/environment-spelling.yml
+++ b/.ci_support/environment-spelling.yml
@@ -1,0 +1,7 @@
+name: spelling
+
+channels:
+  - conda-forge
+
+dependencies:
+  - hunspell-en

--- a/.ci_support/requirements-build.txt
+++ b/.ci_support/requirements-build.txt
@@ -1,0 +1,1 @@
+jupyter-book

--- a/.ci_support/requirements-check-links.txt
+++ b/.ci_support/requirements-check-links.txt
@@ -1,0 +1,2 @@
+pytest-check-links
+requests_cache

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,99 @@
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+
+    - uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: pip-build-${{ hashFiles('.ci_support/requirements-build.txt') }}
+        restore-keys: |
+          pip-build-
+          pip-
+
+    - run: |
+        pip install -U -r .ci_support/requirements-build.txt
+
+    - run: |
+        jupyter-book build .
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: _build
+        path: _build
+
+  spelling:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: _build
+          path: _build
+
+      - name: Cache conda
+        uses: actions/cache@v1
+        with:
+          path: ~/conda_pkgs_dir
+          key: conda-spelling-${{ hashFiles('.ci_support/environment-spelling.yml') }}
+          restore-keys: |
+            conda-spelling-
+            conda-
+
+      - uses: goanpeca/setup-miniconda@v1.6.0
+        with:
+          activate-environment: spelling
+          channel-priority: strict
+          environment-file: .ci_support/environment-spelling.yml
+          use-only-tar-bz2: true
+
+      - shell: bash -l {0}
+        run: |
+          bash .ci_support/check_spelling.sh
+
+  links:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: _build
+          path: _build
+
+      - uses: actions/cache@v2
+        with:
+          path: .pytest-check-links-cache.sqlite
+          key: link-cache
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: pip-check-links-${{ hashFiles('.ci_support/requirements-check-links.txt') }}
+          restore-keys: |
+            pip-check-links-
+            pip-
+
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - run: |
+          pip install -U -r .ci_support/requirements-check-links.txt
+
+      - run: |
+          bash .ci_support/check_links.sh

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ node_modules
 
 # Jupyter Book
 _build
+
+# test cruft
+*.sqlite


### PR DESCRIPTION
- fixes #56

This adds a new workflow which performs:
- spellchecking with `hunspell` against en-US and en-GB (the latter is more frequently updated)
  - this gets installed from `conda-forge`
  - **findings**
    - nothing too surprising: Jupyter, Xeus, etc. aren't in the dictionary... yet!
    - otherwise, awesome! good job team!
- link checking with `pytest-check-links`
  - this gets installed with `pip`
  - currently a bunch of declarativewidth
  - **findings** 
    - a bunch of the declarativewidgets links are broken. they just get skipped for now

I've tried some caching (still learning actions), and the total delta seems not so long. I didn't touch the existing workflows, but they should probably share requirements files. It has been suggested that we might get reusable step definitions (a la azure pipelines) in the future.