### PR TITLE
Kernel handshaking pattern proposal

### DIFF
--- a/jupyter-handshaking/jupyter-handshaking.md
+++ b/jupyter-handshaking/jupyter-handshaking.md
@@ -15,7 +15,7 @@ We propose to implement a handshaking pattern: the client lets the kernel find f
 - The kernel starts, find free ports to bind the shell, control, stdin, heartbeat and iopub sockets. It then connect to the A socket and send the connection information to the client.
 - Upon reception of the connection information, the client connects to the kernel.
 
-The way the client passes its address and the port of the listening socket to the kernel should be similar to that of passing the ports of the kernel socket in the current implementation: a connection file that can be read by local kernels or sent over the network for distant kernels (although this requires an intermediate actor such as a gateway).
+The way the client passes its address and the port of the listening socket to the kernel should be similar to that of passing the ports of the kernel socket in the current implementation: a connection file that can be read by local kernels or sent over the network for remote kernels (although this requires a custom kernel provisioner or "nanny").
 
 The kernel specifies whether it supports the handshake pattern via the "kernel_protocol_version" field in the kernelspec:
 - if the field is missing, or if its value if less than 5.5, the kernel supports passing ports only.
@@ -26,9 +26,9 @@ The kernel specifies whether it supports the handshake pattern via the "kernel_p
 
 Although this enhancement requires changing all the existing kernels, the impact should be limited. Indeed, most of the kernels are based on the kernel wrapper approach, or on xeus.
 
-Most of the clients are based on `jupyter_client`. Therefore, the changes should be limited to this repository only.
+Most of the clients are based on `jupyter_client`. Therefore, the changes should only be limited to this repository or external kernel provisioners.
 
-A transition period where clients and kernels support both mechanisms should allow kernels to gradually migrate to the new version of the protocol. The support of the handshaking pattern should be indicated in the kernelspec.
+A transition period where clients and kernels support both mechanisms should allow kernels to gradually migrate to the new version of the protocol. Support for the handshaking pattern is indicated in the kernelspec via `kernel_protocol_version` as stated above.
 
 ## Relevant Resources (GitHub repositories, Issues, PRs)
 

--- a/jupyter-handshaking/jupyter-handshaking.md
+++ b/jupyter-handshaking/jupyter-handshaking.md
@@ -19,7 +19,7 @@ The way the client passes its address and the port of the listening socket to th
 
 - A new field "kernel_handshake" would be added to the kernelspec specifying whether the said kernel supports the new mechanism.
 - In this case, the connection file passed to the kernel will specify the handshake port instead of the ports for the different channels.
-- The kernel adds the port numbers for the different channels to the connection file, so that other clients can connect to the kernel.
+- When the client receives the port numbers for the different channels from the kernel, it adds them the connection file, so that other clients can connect to the kernel.
 
 If the new field "kernel_handshake" is missing from the kernelspec, the clients should emit a warning, and assume that the new mechanisms is not supported, and recommend that the key is added to the kernelspec.
 

--- a/jupyter-handshaking/jupyter-handshaking.md
+++ b/jupyter-handshaking/jupyter-handshaking.md
@@ -10,16 +10,25 @@ A workaround has been implemented for the latter case, but it does not solve the
 
 We propose to implement a handshaking pattern: the client lets the kernel find free ports and communicate them back via a dedicated socket. It then connects to the kernel. More formely:
 
-- When the client starts, it opens a dedicated socket A for receiving connection information from kernels (channel ports).
-- When launching a new kernel, the client passes its address and the port of this socket to the kernel.
-- The kernel starts, find free ports to bind the shell, control, stdin, heartbeat and iopub sockets. It then connect to the A socket and send the connection information to the client.
+- The kernel launcher is responsible for opening a dedicated socket for receiving connection information from kernels (channel ports). This socket will be refered as the registration socket.
+- When starting a new kernel, the launcher passes the connection information for this socket to the kernel.
+- The kernel starts, find free ports to bind the shell, control, stdin, heartbeat and iopub sockets. It then connect to the registration socket and send the connection information to the client.
 - Upon reception of the connection information, the client connects to the kernel.
 
-The way the client passes its address and the port of the listening socket to the kernel should be similar to that of passing the ports of the kernel socket in the current implementation: a connection file that can be read by local kernels or sent over the network for remote kernels (although this requires a custom kernel provisioner or "nanny"). This connection file should also contain the signature scheme and the key.
+The way the launcher passes the connection information for the registration socket to the kernel should be similar to that of passing the ports of the kernel socket in the current connection pattern: a connection file that can be read by local kernels or sent over the network for remote kernels (although this requires a custom kernel provisioner or "nanny"). This connection file should also contain the signature scheme and the key.
+
+The kernel should not expect the registration socket to exist after it has sent its registration (i.e. it can be closed). Therefore, the kernel should disconnect from the registration socket right after it has sent its connection information.
 
 The kernel specifies whether it supports the handshake pattern via the "kernel_protocol_version" field in the kernelspec:
 - if the field is missing, or if its value if less than 5.5, the kernel supports passing ports only.
 - if the field value is >=5.5, the kernel supports both mechanisms.
+
+### Remarks
+
+This pattern is **NOT** a replacement for the current connection pattern. It is an additional one and kernels will have to implement both of them to be conformant to the Juyter Kernel Protocol specification. Which pattern should be used for the connection if decided by the kernel launcher, depending on the information passed in the initial connection file.
+
+
+A recommended implementation for a multi-kernel client (i.e. jupyter-server) is to have a single long-lived registration socket.
 
 ### Impact on existing implementations
 

--- a/jupyter-handshaking/jupyter-handshaking.md
+++ b/jupyter-handshaking/jupyter-handshaking.md
@@ -1,3 +1,11 @@
+---
+title: Kernel Handshaking pattern
+authors: Johan Mabille (@JohanMabille)
+issue-number:
+pr-number: 66
+date-started: 2021-01-05
+---
+
 # Kernel Handshaking pattern
 
 ## Problem
@@ -18,6 +26,8 @@ We propose to implement a handshaking pattern: the client lets the kernel find f
 The way the launcher passes the connection information for the registration socket to the kernel should be similar to that of passing the ports of the kernel socket in the current connection pattern: a connection file that can be read by local kernels or sent over the network for remote kernels (although this requires a custom kernel provisioner or "nanny"). This connection file should also contain the signature scheme and the key.
 
 The kernel should not expect the registration socket to exist after it has received the acknowledge receipt (i.e. it can be closed). Therefore, the kernel should disconnect from the registration socket right after it has received the acknowledge receipt. A kernel should shutdown itself if it does not receive an acknowledge receipt after some time (the value of the time limit is let to the implementation).
+
+The kernel should write its connection information in a connection file so that other clients can connect to it.
 
 The kernel specifies whether it supports the handshake pattern via the "kernel_protocol_version" field in the kernelspec:
 - if the field is missing, or if its value if less than 5.5, the kernel supports passing ports only.

--- a/jupyter-handshaking/jupyter-handshaking.md
+++ b/jupyter-handshaking/jupyter-handshaking.md
@@ -17,14 +17,10 @@ We propose to implement a handshaking pattern: the client lets the kernel find f
 
 The way the client passes its address and the port of the listening socket to the kernel should be similar to that of passing the ports of the kernel socket in the current implementation: a connection file that can be read by local kernels or sent over the network for distant kernels (although this requires an intermediate actor such as a gateway).
 
-- A new field "kernel_startup_protocol_version" would be added to the metadata section of the kernelspec. It accepts the following values:
-  - `0`: supports passing ports only (assumed if unspecified)
-  - `1`: supports both handshake and passing ports
-  Enventually, a later version of the protocol (eg 2) may drop the support for passing the port numbers.
-- In this case, the connection file passed to the kernel will specify the handshake port instead of the ports for the different channels. The connection file will also specify the address of the client, and a token used to identify the kernel.
-- When the client receives the port numbers for the different channels from the kernel, it adds them the connection file, so that other clients can connect to the kernel.
-
-If the new field "kernel_handshake" is missing from the kernelspec, the clients should emit a warning, and assume that the new mechanisms is not supported, and recommend that the key is added to the kernelspec.
+The kernel specifies whether it supports the handshake pattern via the "protocol_version" field in the kernelspec:
+- if the field is missing, or if its value if less than 5.5, the kernel supports passing ports only.
+- if the field value is >=5.5 and <6, the kernel supports both mechanisms.
+- if the field value is >=6, the kernel supports the handshake pattern. Clients should not assume the kernel still supports the old mechanism.
 
 ### Impact on existing implementations
 

--- a/jupyter-handshaking/jupyter-handshaking.md
+++ b/jupyter-handshaking/jupyter-handshaking.md
@@ -17,7 +17,10 @@ We propose to implement a handshaking pattern: the client lets the kernel find f
 
 The way the client passes its address and the port of the listening socket to the kernel should be similar to that of passing the ports of the kernel socket in the current implementation: a connection file that can be read by local kernels or sent over the network for distant kernels (although this requires an intermediate actor such as a gateway).
 
-- A new field "kernel_handshake" would be added to the kernelspec specifying whether the said kernel supports the new mechanism.
+- A new field "kernel_startup_protocol_version" would be added to the metadata section of the kernelspec. It accepts the following values:
+  - `0`: supports passing ports only (assumed if unspecified)
+  - `1`: supports both handshake and passing ports
+  - `2`: supports handshake only (future value, if we decide to remove the current mechanism)
 - In this case, the connection file passed to the kernel will specify the handshake port instead of the ports for the different channels. The connection file will also specify the address of the client, and a token used to identify the kernel.
 - When the client receives the port numbers for the different channels from the kernel, it adds them the connection file, so that other clients can connect to the kernel.
 

--- a/jupyter-handshaking/jupyter-handshaking.md
+++ b/jupyter-handshaking/jupyter-handshaking.md
@@ -25,7 +25,10 @@ We propose to implement a handshaking pattern: the client lets the kernel find f
 
 The way the launcher passes the connection information for the registration socket to the kernel should be similar to that of passing the ports of the kernel socket in the current connection pattern: a connection file that can be read by local kernels or sent over the network for remote kernels (although this requires a custom kernel provisioner or "nanny"). This connection file should also contain the signature scheme and the key.
 
-The kernel should not expect the registration socket to exist after it has received the acknowledge receipt (i.e. it can be closed). Therefore, the kernel should disconnect from the registration socket right after it has received the acknowledge receipt. A kernel should shutdown itself if it does not receive an acknowledge receipt after some time (the value of the time limit is let to the implementation).
+Reagarding the registration socket lifetime:
+
+- The kernel launcher MAY close the registration socket after completing a kernel's registration. Therefore, the kernel should disconnect from the registration socket right after it has received the acknowledge receipt. A kernel should shutdown itself if it does not receive an acknowledge receipt after some time (the value of the time limit is let to the implementation).
+- To restart a kernel will require the registration socket again, so the kernel launcher SHOULD keep the registration socket open if it expects restarts to be possible, or open a new socket and pass the new registration socket URL to the new process.
 
 The kernel should write its connection information in a connection file so that other clients can connect to it.
 

--- a/jupyter-handshaking/jupyter-handshaking.md
+++ b/jupyter-handshaking/jupyter-handshaking.md
@@ -17,7 +17,7 @@ We propose to implement a handshaking pattern: the client lets the kernel find f
 
 The way the client passes its address and the port of the listening socket to the kernel should be similar to that of passing the ports of the kernel socket in the current implementation: a connection file that can be read by local kernels or sent over the network for distant kernels (although this requires an intermediate actor such as a gateway).
 
-The kernel specifies whether it supports the handshake pattern via the "protocol_version" field in the kernelspec:
+The kernel specifies whether it supports the handshake pattern via the "kernel_protocol_version" field in the kernelspec:
 - if the field is missing, or if its value if less than 5.5, the kernel supports passing ports only.
 - if the field value is >=5.5 and <6, the kernel supports both mechanisms.
 - if the field value is >=6, the kernel supports the handshake pattern. Clients should not assume the kernel still supports the old mechanism.

--- a/jupyter-handshaking/jupyter-handshaking.md
+++ b/jupyter-handshaking/jupyter-handshaking.md
@@ -19,16 +19,13 @@ The way the client passes its address and the port of the listening socket to th
 
 The kernel specifies whether it supports the handshake pattern via the "kernel_protocol_version" field in the kernelspec:
 - if the field is missing, or if its value if less than 5.5, the kernel supports passing ports only.
-- if the field value is >=5.5 and <6, the kernel supports both mechanisms.
-- if the field value is >=6, the kernel supports the handshake pattern. Clients should not assume the kernel still supports the old mechanism.
+- if the field value is >=5.5, the kernel supports both mechanisms.
 
 ### Impact on existing implementations
 
 Although this enhancement requires changing all the existing kernels, the impact should be limited. Indeed, most of the kernels are based on the kernel wrapper approach, or on xeus.
 
 Most of the clients are based on `jupyter_client`. Therefore, the changes should only be limited to this repository or external kernel provisioners.
-
-A transition period where clients and kernels support both mechanisms should allow kernels to gradually migrate to the new version of the protocol. Support for the handshaking pattern is indicated in the kernelspec via `kernel_protocol_version` as stated above.
 
 ## Relevant Resources (GitHub repositories, Issues, PRs)
 

--- a/jupyter-handshaking/jupyter-handshaking.md
+++ b/jupyter-handshaking/jupyter-handshaking.md
@@ -20,7 +20,7 @@ The way the client passes its address and the port of the listening socket to th
 - A new field "kernel_startup_protocol_version" would be added to the metadata section of the kernelspec. It accepts the following values:
   - `0`: supports passing ports only (assumed if unspecified)
   - `1`: supports both handshake and passing ports
-  - `2`: supports handshake only (future value, if we decide to remove the current mechanism)
+  Enventually, a later version of the protocol (eg 2) may drop the support for passing the port numbers.
 - In this case, the connection file passed to the kernel will specify the handshake port instead of the ports for the different channels. The connection file will also specify the address of the client, and a token used to identify the kernel.
 - When the client receives the port numbers for the different channels from the kernel, it adds them the connection file, so that other clients can connect to the kernel.
 

--- a/jupyter-handshaking/jupyter-handshaking.md
+++ b/jupyter-handshaking/jupyter-handshaking.md
@@ -1,0 +1,54 @@
+# Kernel Handshaking pattern
+
+## Problem
+
+The current implementation of Jupyter client makes it responsible for finding available ports and pass them to a new starting kernel. The issue is that a new process can start using one of these ports before the kernel has started, resulting in a ZMQError when the kernel starts. This is even more problematic when spawning a lot of kernels in a short laps of time, because the client may find available ports that have already been assigned to another kernel.
+
+A workaround has been implemented for the latter case, but it does not solve the former one.
+
+## Proposed Enhancement
+
+We propose to implement a handshaking pattern: the client lets the kernel find free ports and communicate them back via a dedicated socket. It then connects to the kernel. More formely:
+
+- When the client starts, it opens a dedicated socket A for receiving connection information from kernels (channel ports).
+- When launching a new kernel, the client passes its address and the port of this socket to the kernel.
+- The kernel starts, find free ports to bind the shell, control, stdin, heartbeat and iopub sockets. It then connect to the A socket and send the connection information to the client.
+- Upon reception of the connection information, the client connects to the kernel.
+
+The way the client passes its address and the port of the listening socket to the kernel should be similar to that of passing the ports of the kernel socket in the current implementation: a connection file that can be read by local kernels or sent over the network for distant kernels (although this requires an intermediate actor such as a gateway).
+
+- A new field "kernel_handshake" would be added to the kernelspec specifying whether the said kernel supports the new mechanism.
+- In this case, the connection file passed to the kernel will specify the handshake port instead of the ports for the different channels.
+- The kernel adds the port numbers for the different channels to the connection file, so that other clients can connect to the kernel.
+
+If the new field "kernel_handshake" is missing from the kernelspec, the clients should emit a warning, and assume that the new mechanisms is not supported, and recommend that the key is added to the kernelspec.
+
+### Impact on existing implementations
+
+Although this enhancement requires changing all the existing kernels, the impact should be limited. Indeed, most of the kernels are based on the kernel wrapper approach, or on xeus.
+
+Most of the clients are based on `jupyter_client`. Therefore, the changes should be limited to this repository only.
+
+A transition period where clients and kernels support both mechanisms should allow kernels to gradually migrate to the new version of the protocol. The support of the handshaking pattern should be indicated in the kernelspec.
+
+## Relevant Resources (GitHub repositories, Issues, PRs)
+
+### GitHub repositories
+
+- Jupyter Client: https://github.com/jupyter/jupyter_client
+The Jupyter protocol client APIs
+- Voilà: https://github.com/voila-dashboards/voila
+Voilà turns Jupyter notebooks into standalone web applications
+- IPyKernel: https://github.com/ipython/ipykernel
+IPython kernel for Jupyter
+- Xeus: https://github.com/jupyter-xeus/xeus
+The C++ implementation of the Jupyter kernel protocol
+
+### GitHub Issues
+
+- Spawning many kernels may result in ZMQError (https://github.com/jupyter/jupyter_client/issues/487)
+- Spawning ~20 requests at a time results in a ZMQError  (https://github.com/voila-dashboards/voila/issues/408#issuecomment-539968325)
+
+### GitHub Pull Requests
+
+- Prevent two kernels to have the same ports (https://github.com/jupyter/jupyter_client/pull/490)

--- a/jupyter-handshaking/jupyter-handshaking.md
+++ b/jupyter-handshaking/jupyter-handshaking.md
@@ -15,7 +15,7 @@ We propose to implement a handshaking pattern: the client lets the kernel find f
 - The kernel starts, find free ports to bind the shell, control, stdin, heartbeat and iopub sockets. It then connect to the A socket and send the connection information to the client.
 - Upon reception of the connection information, the client connects to the kernel.
 
-The way the client passes its address and the port of the listening socket to the kernel should be similar to that of passing the ports of the kernel socket in the current implementation: a connection file that can be read by local kernels or sent over the network for remote kernels (although this requires a custom kernel provisioner or "nanny").
+The way the client passes its address and the port of the listening socket to the kernel should be similar to that of passing the ports of the kernel socket in the current implementation: a connection file that can be read by local kernels or sent over the network for remote kernels (although this requires a custom kernel provisioner or "nanny"). This connection file should also contain the signature scheme and the key.
 
 The kernel specifies whether it supports the handshake pattern via the "kernel_protocol_version" field in the kernelspec:
 - if the field is missing, or if its value if less than 5.5, the kernel supports passing ports only.

--- a/jupyter-handshaking/jupyter-handshaking.md
+++ b/jupyter-handshaking/jupyter-handshaking.md
@@ -18,7 +18,7 @@ We propose to implement a handshaking pattern: the client lets the kernel find f
 The way the client passes its address and the port of the listening socket to the kernel should be similar to that of passing the ports of the kernel socket in the current implementation: a connection file that can be read by local kernels or sent over the network for distant kernels (although this requires an intermediate actor such as a gateway).
 
 - A new field "kernel_handshake" would be added to the kernelspec specifying whether the said kernel supports the new mechanism.
-- In this case, the connection file passed to the kernel will specify the handshake port instead of the ports for the different channels.
+- In this case, the connection file passed to the kernel will specify the handshake port instead of the ports for the different channels. The connection file will also specify the address of the client, and a token used to identify the kernel.
 - When the client receives the port numbers for the different channels from the kernel, it adds them the connection file, so that other clients can connect to the kernel.
 
 If the new field "kernel_handshake" is missing from the kernelspec, the clients should emit a warning, and assume that the new mechanisms is not supported, and recommend that the key is added to the kernelspec.


### PR DESCRIPTION
# Kernel Handshaking pattern

The current implementation of Jupyter client makes it responsible for finding available ports and pass them to a new starting kernel. The issue is that a new process can start using one of these ports before the kernel has started, resulting in a ZMQError when the kernel starts. This is even more problematic when spawning a lot of kernels in a short laps of time, because the client may find available ports that have already been assigned to another kernel.

A workaround has been implemented for the latter case, but it does not solve the former one.

This proposal aims to fix this issue for good, with a handshaking pattern.

## Voting from @jupyter/software-steering-council 

- @echarles 
  - [ ] Yes
  - [x] No
  - [ ] Abstain
- @fcollonval 
  - [ ] Yes
  - [ ] No 
  - [x] Abstain
- @ibdafna 
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @isabela-pf 
  - [ ] Yes 
  - [ ] No
  - [ ] Abstain
- @ivanov
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @JohanMabille 
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @minrk
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @rpwagner 
  - [x] Yes
  - [ ] No
  - [ ] Abstain 
- @SylvainCorlay
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @willingc
  - [ ] Yes
  - [ ] No
  - [ ] Abstain
- @Zsailer 
  - [x] Yes
  - [ ] No 
  - [ ] Abstain  