### PR TITLE
Add write permission for the bot

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,10 @@ on:
     branches:
     - master
 
+# Allow the bot to push to the repository
+permissions:
+  contents: write
+
 # This job installs dependencies, build the book, and pushes it to `gh-pages`
 jobs:
   deploy-book:


### PR DESCRIPTION
This may fix #76, but ideally the write permission would be restricted to `gh-pages`. Not sure if this is possible.