### PR TITLE
JEP for copy-to-globals support in debugger_info

### DIFF
--- a/debugger-info-copy-to-globals/debugger-info-copy-to-globals.md
+++ b/debugger-info-copy-to-globals/debugger-info-copy-to-globals.md
@@ -23,3 +23,47 @@ UI if this is supported by the kernel before displaying the corresponding menu e
 
 We propose to add a new `copyToGlobals` boolean field to the `debugger_info`
 response which will inform the UI that this request is supported.
+
+## Reference-level explanation
+
+This boolean flag should be included in the `debugger_info` response from the kernel
+which supports the feature. It is optional, assuming that its absence is understood
+as `false` from the client perspective.
+
+If the feature is supported, the kernel must provide a function for copying a variable
+from a local scope to the global scope.
+The communication between the UI and the kernel (request - response) will have the
+structures described at
+https://jupyter-client.readthedocs.io/en/latest/messaging.html#copytoglobals.
+
+- Request (from UI to kernel)
+
+  ```json
+  {
+    'type': 'request',
+    'command': 'copyToGlobals',
+    'arguments': {
+      # the variable to copy from the frame corresponding to `srcFrameId`
+      'srcVariableName': str,
+      'srcFrameId': int,
+      # the copied variable name in the global scope
+      'dstVariableName': str
+    }
+  }
+  ```
+
+- Response (from kernel to UI)
+
+  ```json
+  {
+    'type': 'response',
+    'success': bool,
+    'command': 'setExpression',
+    'body': {
+      # string representation of the copied variable
+      'value': str,
+      # type of the copied variable
+      'type': str,
+      'variablesReference': int
+    }
+  }

--- a/debugger-info-copy-to-globals/debugger-info-copy-to-globals.md
+++ b/debugger-info-copy-to-globals/debugger-info-copy-to-globals.md
@@ -54,7 +54,7 @@ https://jupyter-client.readthedocs.io/en/latest/messaging.html#copytoglobals.
 
 - Response (from kernel to UI)
 
-  ```json
+  ```python
   {
     'type': 'response',
     'success': bool,

--- a/debugger-info-copy-to-globals/debugger-info-copy-to-globals.md
+++ b/debugger-info-copy-to-globals/debugger-info-copy-to-globals.md
@@ -1,0 +1,25 @@
+---
+title: Debugger support to copyToGlobals
+authors: Nicolas Brichet (@brichet)
+issue-number: xxx
+pr-number: xxx
+date-started: 2023-02-20
+---
+
+# Summary
+
+This JEP introduces a new field to the kernel debugger_info response. This new
+field will inform the UI that the debugger supports the `copyToGlobals` request.
+
+# Motivation
+
+The `copyToGlobals` request has been introduced in
+[ipykernel](https://github.com/ipython/ipykernel/pull/1055) and in
+[xeus-python](https://github.com/jupyter-xeus/xeus-python/pull/562) to copy a local
+variable to the global scope during a breakpoint. It would be useful to inform the
+UI if this is supported by the kernel before displaying the corresponding menu entry.
+
+# Proposed Enhancement
+
+We propose to add a new `copyToGlobals` boolean field to the `debugger_info`
+response which will inform the UI that this request is supported.

--- a/debugger-info-copy-to-globals/debugger-info-copy-to-globals.md
+++ b/debugger-info-copy-to-globals/debugger-info-copy-to-globals.md
@@ -38,7 +38,7 @@ https://jupyter-client.readthedocs.io/en/latest/messaging.html#copytoglobals.
 
 - Request (from UI to kernel)
 
-  ```json
+  ```python
   {
     'type': 'request',
     'command': 'copyToGlobals',


### PR DESCRIPTION
Introducing a new field to the kernel debugger_info response. 
This new field will inform the UI that the debugger supports the `copyToGlobals` request.

Related to https://github.com/jupyterlab/jupyterlab/pull/13476#discussion_r1111061085, which introduces a new feature in the debugger. It would be useful to know if this feature is supported by the kernel from UI side.

cc. @JohanMabille @krassowski 

## Voting from @jupyter/software-steering-council 

- @echarles 
  - [ ] Yes
  - [ ] No
  - [ ] Abstain
- @fcollonval 
  - [x] Yes
  - [ ] No 
  - [ ] Abstain
- @gabalafou
  - [ ] Yes
  - [ ] No
  - [x] Abstain 
- @ibdafna 
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @ivanov
  - [ ] Yes
  - [ ] No
  - [x] Abstain
- @JohanMabille 
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @marthacryan
  - [ ] Yes
  - [ ] No
  - [ ] Abstain
- @minrk
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @rpwagner 
  - [ ] Yes
  - [ ] No
  - [x] Abstain 
- @SylvainCorlay
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @Zsailer 
  - [x] Yes
  - [ ] No 
  - [ ] Abstain