### PR TITLE
JEP for specifying the connectionfile

### DIFF
--- a/connectionfile-spec/connectionfile-spec.md
+++ b/connectionfile-spec/connectionfile-spec.md
@@ -15,10 +15,9 @@ The connection file is [documented](https://github.com/jupyter/jupyter_client/bl
 ## Proposed Enhancement
 
 We propose to specify the connection file with the JSON schema joined in this PR. The specification would reflect
-[the current description of the connection file](https://jupyter-client.readthedocs.io/en/stable/kernels.html#connection-files),
-and adds an optional `kernel_protocol_version` field.
+[the current description of the connection file](https://jupyter-client.readthedocs.io/en/stable/kernels.html#connection-files).
 
-The specification and the documentation of the connection file will be stored along side [those of the kernel protocol](https://github.com/jupyter-standards/kernel-protocol)
+The documentation of the connection file will be stored along side [those of the kernel protocol](https://github.com/jupyter-standards/kernel-protocol) while its specification will be stored in the [Jupyter schema repo](https://github.com/jupyter/schema).
 
 ### Impact on existing implementations
 

--- a/connectionfile-spec/connectionfile-spec.md
+++ b/connectionfile-spec/connectionfile-spec.md
@@ -1,0 +1,25 @@
+---
+title: connection file specification
+authors: Johan Mabille
+issue-number: XX
+pr-number: XX
+date-started: "2023-04-19"
+---
+
+# Specification of the connection file
+
+## Problem
+
+The connection file is [documented](https://github.com/jupyter/jupyter_client/blob/main/docs/kernels.rst) aside the kernel protocol documentation, but it is not *specified*.
+
+## Proposed Enhancement
+
+We propose to specify the connection file with the JSON schema joined in this PR. The specification would reflect
+[the current description of the connection file](https://jupyter-client.readthedocs.io/en/stable/kernels.html#connection-files),
+and adds an optional `kernel_protocol_version` field.
+
+The specification and the documentation of the connectio filewill be stored aside [those of the kernel protocol](https://github.com/jupyter-standards/kernel-protocol)
+
+### Impact on existing implementations
+
+None, this JEP only specifies the current implementations.

--- a/connectionfile-spec/connectionfile-spec.md
+++ b/connectionfile-spec/connectionfile-spec.md
@@ -18,7 +18,7 @@ We propose to specify the connection file with the JSON schema joined in this PR
 [the current description of the connection file](https://jupyter-client.readthedocs.io/en/stable/kernels.html#connection-files),
 and adds an optional `kernel_protocol_version` field.
 
-The specification and the documentation of the connectio filewill be stored aside [those of the kernel protocol](https://github.com/jupyter-standards/kernel-protocol)
+The specification and the documentation of the connection file will be stored along side [those of the kernel protocol](https://github.com/jupyter-standards/kernel-protocol)
 
 ### Impact on existing implementations
 

--- a/connectionfile-spec/connectionfile.schema.json
+++ b/connectionfile-spec/connectionfile.schema.json
@@ -11,7 +11,7 @@
             "required": ["signature_scheme", "key"],
             "properties": {
                 "signature_scheme": {
-                    "type": "string",
+                    "enum": ["hmac-md5","hmac-sha256","hmac-sha512"],
                     "description": "scheme used to sign the messages"
                 },
                 "key": {
@@ -34,23 +34,23 @@
                     "description": "ip of the machine where the kernel runs"
                 },
                 "shell_port": {
-                    "type": "string",
+                    "type": ["integer","string"],
                     "description": "port used by the shell channel"
                 },
                 "control_port": {
-                    "type": "string",
+                    "type": ["integer","string"],
                     "description": "port used by the control channel"
                 },
                 "stdin_port": {
-                    "type": "string",
+                    "type": ["integer","string"],
                     "description": "port used by the stdin channel"
                 },
                 "hb_port": {
-                    "type": "string",
+                    "type": ["integer","string"],
                     "description": "port used by the heartbeat channel"
                 },
                 "iopub_port": {
-                    "type": "string",
+                    "type": ["ingerer","string"],
                     "description": "port used by the iopub channel"
                 }
             }

--- a/connectionfile-spec/connectionfile.schema.json
+++ b/connectionfile-spec/connectionfile.schema.json
@@ -1,0 +1,64 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://schema.jupyter.org/connectionfile-v1.0.schema.json",
+    "title": "Jupyter Connection File",
+    "description": "A description of the data required to connect and send messages to a Jupyter Kernel",
+    "type": "object",
+
+    "definitions": {
+        "signature": {
+            "type": "object",
+            "required": ["signature_scheme", "key"],
+            "properties": {
+                "signature_scheme": {
+                    "type": "string",
+                    "description": "scheme used to sign the messages"
+                },
+                "key": {
+                    "type": "string",
+                    "description": "key used to sign the messages"
+                }
+            }
+        },
+        "kernel_network": {
+            "type": "object",
+            "required": ["transport", "ip", "shell_port", "control_port", "stdin_port", "hb_port", "iopub_port"],
+            "properties": {
+                "transport": {
+                    "type": "string",
+                    "description": "transport protocol",
+                    "enum": ["tcp", "ipc", "inproc"]
+                },
+                "ip": {
+                    "type": "string",
+                    "description": "ip of the machine where the kernel runs"
+                },
+                "shell_port": {
+                    "type": "string",
+                    "description": "port used by the shell channel"
+                },
+                "control_port": {
+                    "type": "string",
+                    "description": "port used by the control channel"
+                },
+                "stdin_port": {
+                    "type": "string",
+                    "description": "port used by the stdin channel"
+                },
+                "hb_port": {
+                    "type": "string",
+                    "description": "port used by the heartbeat channel"
+                },
+                "iopub_port": {
+                    "type": "string",
+                    "description": "port used by the iopub channel"
+                }
+            }
+        }
+    },
+    "allOf": [
+        { "$ref": "#/definitions/kernel_network" },
+        { "$ref": "#/definitions/signature" }
+    ]
+}
+


### PR DESCRIPTION
# Connection file JSON schema

This proposes to specify the connection file through a JSON schema, and have the specification and documentation live in a [dedicated repo](https://github.com/jupyter-standards/kernel-protocol).

The JSON schema is joined as a standalone file.

---

I(s been a while since we proposed to move to the voting phase, let's fix it now ;) Ntice that further JSON specs should not been JEPs, but PRs to https://github.com/jupyter/schema

## Voting from @jupyter/software-steering-council 

- @gabalafou
  - [x] Yes
  - [ ] No
  - [ ] Abstain 
- @ivanov
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @JohanMabille 
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @jtpio 
  - [x] Yes
  - [ ] No
  - [ ] Abstain 
- @marthacryan
  - [x] Yes
  - [ ] No
  - [ ] Abstain 
- @martinRenou
  - [x] Yes
  - [ ] No
  - [ ] Abstain 
- @minrk
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @rpwagner 
  - [x] Yes
  - [ ] No
  - [ ] Abstain 
- @SylvainCorlay
  - [x] Yes
  - [ ] No
  - [ ] Abstain
- @vidartf 
  - [x] Yes
  - [ ] No 
  - [ ] Abstain